### PR TITLE
Raise error if no price or title found

### DIFF
--- a/complex_frogs/scraper/amazon_google_scraper.py
+++ b/complex_frogs/scraper/amazon_google_scraper.py
@@ -77,6 +77,8 @@ class AmazonGoogleScraper(BaseScraper):
                     self.title = product_card.css_first(self.TITLE_SELECTOR).text(
                         strip=True,
                     )
+            if not self.price or not self.title:
+                raise AttributeError  # noqa TRY301
         except AttributeError:
             self.price = self.PRICE_404
             self.title = self.TITLE_404


### PR DESCRIPTION
This pull request adds an error handling mechanism to raise an AttributeError if no price or title is found in the product card. This ensures that the program doesn't proceed with incomplete data.